### PR TITLE
Fix errors due to group and repository API breaking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ run/*
 **/cxone_tenant
 env
 mitm*
+*.csv
 
 **/*.whl
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## v1.7
+* Fixed an issue causing the scheduler to not start due to a Checkmarx One breaking API change when retrieving groups.
+* Fixed an issue causing code repository import projects to not be scheduled due to a Checkmarx One breaking API change
+  when retrieving code repository details.
+
 ## v1.6
 * Added better handling when the SCM credentials expire for a code repository import project.
 
@@ -12,7 +17,6 @@ can kick off a scan.  (If the PAT is expired, the scan will fail.)
   * scorecard
 * Added throttling to API calls while invoking scans.
 * Added resilience to common network failures.  Retry options can be configured to increase the number of retries before failure.
-
 
 ## v1.4
 * Logic for selecting primary branch updated.  If only one protected branch is defined in the code repository

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ cron-validator==1.0.8
 posix-ipc==1.3.0
 aiofiles==24.1.0
 pytest==8.3.4
-https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.0.10/cxone_api-1.0.10-py3-none-any.whl
+https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.1.1/cxone_api-1.1.1-py3-none-any.whl
 


### PR DESCRIPTION
The cxone-async-api module has been updated to handle the breaking API changes.