### PR TITLE
Fix for CVE-2026-31431 (CopyFail)

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -9,7 +9,7 @@ jobs:
           - name: Fetch Code
             uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
           - name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+            uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
             with:
               install: true
               platforms: linux/amd64

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -7,9 +7,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
           - name: Fetch Code
-            uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+            uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
           - name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+            uses: docker/setup-buildx-action@de0fac2e4500dabe0009e67214ff5f5447ce83dd
             with:
               install: true
               platforms: linux/amd64
@@ -21,7 +21,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
           - name: Fetch Code
-            uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+            uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
           - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: '3.12'

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -23,7 +23,7 @@ jobs:
           - name: Fetch Code
             uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-          - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+          - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
           - name: Execute Helm template test
             run: helm template --debug ./helm
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Fetch Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.12'
       - name: Install packages

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -9,7 +9,7 @@ jobs:
           - name: Fetch Code
             uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
           - name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
             with:
               install: true
               platforms: linux/amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch Code @ tag ${{ inputs.tag }}
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/tags/${{ inputs.tag }}
 
@@ -48,7 +48,7 @@ jobs:
     needs: [publish-scheduler]
     steps:
       - name: Fetch Code @ tag ${{ inputs.tag }}
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/tags/${{ inputs.tag }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ env:
 jobs:
   publish-scheduler:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,17 +9,14 @@ on:
           description: 'Set to true if published build is a prerelease'
           type: boolean
           required: true
-      secrets:
-        PACKAGE_USER:
-          required: true
-        PACKAGE_PAT:
-          required: true
 env:
   DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/cxone/scan-scheduler
                 
 jobs:
   publish-scheduler:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Set up Docker Buildx
         id: buildx
@@ -29,8 +26,8 @@ jobs:
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
         with:
           registry: ghcr.io
-          username: ${{ secrets.PACKAGE_USER }}
-          password: ${{ secrets.PACKAGE_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch Code @ tag ${{ inputs.tag }}
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
-        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
           allowUpdates: true
           artifactErrorsFailBuild: true

--- a/.github/workflows/invoke-build.yml
+++ b/.github/workflows/invoke-build.yml
@@ -9,11 +9,6 @@ on:
           description: 'Set to true if publishing a pre-release.'
           required: true
           type: boolean
-      secrets:
-          PACKAGE_USER:
-              required: true
-          PACKAGE_PAT:
-              required: true
               
 jobs:
   create-tag:
@@ -32,9 +27,6 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
       prerelease: ${{ inputs.prerelease }}
-    secrets:
-      PACKAGE_USER: ${{ secrets.PACKAGE_USER }}
-      PACKAGE_PAT: ${{ secrets.PACKAGE_PAT }}
 
   remove-tag-on-failure:
     needs: [create-tag, publish-release]

--- a/.github/workflows/invoke-build.yml
+++ b/.github/workflows/invoke-build.yml
@@ -24,6 +24,8 @@ jobs:
   publish-release:
     needs: [create-tag]
     uses: ./.github/workflows/build.yml
+    permissions:
+      packages: write
     with:
       tag: ${{ inputs.tag }}
       prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/invoke-build.yml
+++ b/.github/workflows/invoke-build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5
       - name: Fetch Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         if: env.WORKFLOW_CONCLUSION == 'failure'
 
       - name: Remove CodeTag

--- a/.github/workflows/invoke-build.yml
+++ b/.github/workflows/invoke-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Tag repo ${{ inputs.tag }}
-        uses: richardsimko/update-tag@e173a8ef8f54ab526a91dad6139a25efed62424c
+        uses: richardsimko/update-tag@aab2434e9a5040687874aa39d1c6377ec0cb0d94
         with:
           tag_name: ${{ inputs.tag }}
         env:
@@ -31,16 +31,13 @@ jobs:
   remove-tag-on-failure:
     needs: [create-tag, publish-release]
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ failure() || cancelled() }}
     steps:
-      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5
       - name: Fetch Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        if: env.WORKFLOW_CONCLUSION == 'failure'
 
       - name: Remove CodeTag
         run: git push origin ':refs/tags/${{ inputs.tag }}'
-        if: env.WORKFLOW_CONCLUSION == 'failure'
     
         
     

--- a/.github/workflows/invoke-build.yml
+++ b/.github/workflows/invoke-build.yml
@@ -24,8 +24,6 @@ jobs:
   publish-release:
     needs: [create-tag]
     uses: ./.github/workflows/build.yml
-    permissions:
-      packages: write
     with:
       tag: ${{ inputs.tag }}
       prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/invoke-build.yml
+++ b/.github/workflows/invoke-build.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Fetch Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set Tag
-        run: git push origin '${{ inputs.tag }}'
+        run: |
+          git tag '${{ inputs.tag }}'
+          git push origin '${{ inputs.tag }}'
 
         
   publish-release:

--- a/.github/workflows/invoke-build.yml
+++ b/.github/workflows/invoke-build.yml
@@ -14,12 +14,12 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
-      - name: Tag repo ${{ inputs.tag }}
-        uses: richardsimko/update-tag@aab2434e9a5040687874aa39d1c6377ec0cb0d94
-        with:
-          tag_name: ${{ inputs.tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Fetch Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Set Tag
+        run: git push origin '${{ inputs.tag }}'
+        
         
   publish-release:
     needs: [create-tag]

--- a/.github/workflows/invoke-build.yml
+++ b/.github/workflows/invoke-build.yml
@@ -14,12 +14,11 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
-    steps:
       - name: Fetch Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set Tag
         run: git push origin '${{ inputs.tag }}'
-        
+
         
   publish-release:
     needs: [create-tag]

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Fetch Code
         continue-on-error: true
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: refs/tags/${{ needs.make-tag-string.outputs.tag }}
       - name: Fail if tag ${{ needs.make-tag-string.outputs.tag }} exists

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,6 +38,8 @@ jobs:
 
   invoke-build-for-publish:
     uses: ./.github/workflows/invoke-build.yml
+    permissions:
+      packages: write
     with:
       tag: ${{ needs.make-tag-string.outputs.tag }}
       prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,6 +40,7 @@ jobs:
     uses: ./.github/workflows/invoke-build.yml
     permissions:
       packages: write
+      contents: write
     with:
       tag: ${{ needs.make-tag-string.outputs.tag }}
       prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -41,8 +41,5 @@ jobs:
     with:
       tag: ${{ needs.make-tag-string.outputs.tag }}
       prerelease: ${{ inputs.prerelease }}
-    secrets:
-      PACKAGE_USER: ${{ secrets.PACKAGE_USER }}
-      PACKAGE_PAT: ${{ secrets.PACKAGE_PAT }}
     needs: [make-tag-string, validate-no-tag]
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Fetch Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -21,7 +21,7 @@ jobs:
       statuses: write
     steps:
       - name: Fetch Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Scan with CxOne++ Action
         id: cxscan
-        uses: checkmarx-ts/cxone-plusplus-github-action@v2
+        uses: checkmarx-ts/cxone-plusplus-github-action@9e69646151d1564d227e7979ce9780b422bdf2f4
         with:
           cx-tenant: ${{ secrets.CXONE_TENANT }}
           cx-client-id: ${{ secrets.CXONE_CLIENT_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get autoremove -y && \
     apt-get clean && \
     groupadd -U nobody scheduler && \
-    mkdir -p /opt/cxone && \
-    touch /opt/cxone/certs.crt && \
-    chown root:scheduler /opt/cxone/certs.crt && \
-    chmod 660 /opt/cxone/certs.crt
+    mkdir -p /opt/cxone/certs && \
+    chown root:scheduler /opt/cxone/certs && \
+    chmod 770 /opt/cxone/certs
+
 
 COPY requirements.txt /opt/cxone/
 COPY *.py entrypoint.sh *.json /opt/cxone/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ USER root
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends tzdata python3 python3-pip && \
+    apt-get install -y --no-install-recommends tzdata=2026a-3ubuntu1 python3=3.14.3-0ubuntu2 python3-pip=25.1.1+dfsg-1ubuntu2 && \
     apt-get remove -y perl && \
     apt-get autoremove -y && \
     apt-get clean && \
@@ -34,7 +34,7 @@ CMD ["scheduler"]
 ENTRYPOINT ["/opt/cxone/entrypoint.sh"]
 
 FROM base AS debug
-RUN apt-get install -y python3-debugpy python3-pytest
+RUN apt-get install -y python3-debugpy=1.8.19+ds-1ubuntu3 python3-pytest=9.0.2-4
 COPY requirements.txt *.whl /opt/cxone/
 RUN [ -f *.whl ] && pip install --no-cache-dir --break-system-packages *.whl || :
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04 AS base
 LABEL org.opencontainers.image.source="https://github.com/checkmarx-ts/cxone-scan-scheduler"
 LABEL org.opencontainers.image.vendor="Checkmarx Professional Services"
 LABEL org.opencontainers.image.title="Checkmarx One Scan Scheduler"
@@ -8,31 +8,36 @@ USER root
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
-    apt-get install -y cron python3.12 python3-pip python3-debugpy bash && \
-    usermod -s /bin/bash nobody && \
-    mkdir -p /opt/cxone && \
-    mkfifo /opt/cxone/logfifo && \
-    chown nobody:root /opt/cxone/logfifo
-
-
-WORKDIR /opt/cxone
-COPY *.txt *.whl /opt/cxone/
-
-RUN pip install -r requirements.txt --no-cache-dir --break-system-packages && \
+    apt-get install -y python3 python3-pip && \
     apt-get remove -y perl && \
     apt-get autoremove -y && \
     apt-get clean && \
-    dpkg --purge $(dpkg --get-selections | grep deinstall | cut -f1)
+    groupadd -U nobody scheduler && \
+    mkdir -p /opt/cxone && \
+    touch /opt/cxone/certs.crt && \
+    chown root:scheduler /opt/cxone/certs.crt && \
+    chmod 660 /opt/cxone/certs.crt
 
-RUN [ -f *.whl ] && pip install --no-cache-dir --break-system-packages *.whl || :
-
+COPY requirements.txt /opt/cxone/
 COPY *.py entrypoint.sh *.json /opt/cxone/
 COPY logic /opt/cxone/logic
 COPY utils /opt/cxone/utils
 COPY scan /opt/cxone/scan
 
-RUN ln -s scheduler.py scheduler && \
+WORKDIR /opt/cxone
+RUN pip install -r requirements.txt --no-cache-dir --break-system-packages && \
+    rm requirements.txt && \
+    ln -s scheduler.py scheduler && \
     ln -s scheduler.py audit
 
 CMD ["scheduler"]
 ENTRYPOINT ["/opt/cxone/entrypoint.sh"]
+
+FROM base AS debug
+RUN apt-get install -y python3-debugpy python3-pytest
+COPY requirements.txt *.whl /opt/cxone/
+RUN [ -f *.whl ] && pip install --no-cache-dir --break-system-packages *.whl || :
+
+FROM base AS release
+USER nobody
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ LABEL org.opencontainers.image.description="Schedules scans for projects in Chec
 
 USER root
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
-    apt-get install -y python3 python3-pip && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends tzdata python3 python3-pip && \
     apt-get remove -y perl && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -351,8 +351,31 @@ configuration values that will be used to configure the container's runtime envi
 be overridden via the Helm command line or your own local copy of the file.  While it is possible to modify the `values.yaml` file directly before
 installing the Helm chart, doing so will make it more difficult to update the deployment with new releases.
 
-After the Helm chart is installed, you must define the generic secret containing the required secret values in the `checkmarx` namespace.
-One method is to deploy the generic secret via the `kubectl` command line.  Example:
+### Minimal Install with Helm
+
+A minimal install of the latest release with Helm is shown in the example below:
+
+```bash
+helm install scheduler https://github.com/checkmarx-ts/cxone-scan-scheduler/releases/latest/download/cxone-scan-scheduler_helm.tgz \
+    --set cxone.deployment.secrets_name=cxone-scan-scheduler-secrets \
+    --set cxone.connection.multitenant.region=US \
+    --set cxone.policies.debug="* * * * *"
+```
+The scheduler will not immediately start after the install.  This is due to the missing required secrets deployment with the name
+`cxone-scan-scheduler-secrets`.
+
+This install does the following:
+
+* Sets the name of the secrets that will be supplied in a later command to `cxone-scan-scheduler-secrets`.
+* Sets the multi-tenant region to `US`.
+* Adds a schedule policy named `debug` to start scheduled scans every minute.
+
+The options provided to the settings should be modified to meet your installation requirements.
+
+### Deploying the Secrets
+
+After the Helm chart is installed, it will not execute until deployment of a generic secret containing the required secret values
+in the `checkmarx` namespace. One method is to deploy the generic secret via the `kubectl` command line.  Example:
 
 ```bash
 kubectl create secret generic --namespace=checkmarx cxone-scan-scheduler-secrets \ 
@@ -361,28 +384,26 @@ kubectl create secret generic --namespace=checkmarx cxone-scan-scheduler-secrets
     --from-literal=cxone_oauth_client_secret=<oauth client secret>
 ```
 
+### Using Custom CA Certificates
+
 To map custom CA certificates to the container, provide the name of a ConfigMap
 for the `cxone.deployment.ca_certs_configmap_name` configuration parameter that holds the names of files containing custom CA
-certificates.  In the following example, the ConfigMap named "cxone-scheduler-custom-cas" is created
+certificates.  In the following example, the ConfigMap named `cxone-scheduler-custom-cas` is created
 with the contents of the file `custom_ca.crt`:
 
 ```bash
 kubectl create configmap --namespace=checkmarx cxone-scheduler-custom-cas --from-file=custom_ca.crt
 ```
 
-If the value of `cxone.deployment.ca_certs_configmap_name` is not provided, no custom CA certificates
-will be mapped to the container.
-
-A minimal install of the latest release with Helm is shown in the example below.  After installing
-the Helm chart, the generic secret and ConfigMap need to be manually created in the `checkmarx` namespace for
-the scheduler to start.
+Then to install the custom CA, set `cxone.deployment.ca_certs_configmap_name` to use the ConfigMap.
 
 ```bash
-helm install scheduler https://github.com/checkmarx-ts/cxone-scan-scheduler/releases/latest/download/cxone-scan-scheduler_helm.tgz \
-    --set cxone.deployment.secrets_name=cxone-scan-scheduler-secrets \
-    --set cxone.connection.multitenant.region=US \
-    --set cxone.policies.debug="* * * * *"
+helm upgrade scheduler --reuse-values \
+--set cxone.deployment.ca_certs_configmap_name=cxone-scheduler-custom-cas
 ```
+
+If the value of `cxone.deployment.ca_certs_configmap_name` is not provided, no custom CA certificates
+will be mapped to the container.
 
 ## Other Notes
 

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ the Helm chart, the generic secret and ConfigMap need to be manually created in 
 the scheduler to start.
 
 ```bash
-helm install scheduler https://github.com/checkmarx-ts/cxone-scan-scheduler/releases/latest/cxone-scan-scheduler_helm.tgz \
+helm install scheduler https://github.com/checkmarx-ts/cxone-scan-scheduler/releases/latest/download/cxone-scan-scheduler_helm.tgz \
     --set cxone.deployment.secrets_name=cxone-scan-scheduler-secrets \
     --set cxone.connection.multitenant.region=US \
     --set cxone.policies.debug="* * * * *"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## v2.1
 * Docker image upgraded to remediate CVE-2026-31431 (Copy Fail)
+* The container now executes as a low-privileged user.
 
 ## v2.0
 * The memory footprint for the scheduler has been reduced significantly by removing the use of crond.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,9 @@
 ## v2.1
 * Docker image upgraded to remediate CVE-2026-31431 (Copy Fail)
 * The container now executes as a low-privileged user.
+* As of the time of release, CVE-2026-43284 (Dirty Frag) is reported to affect Ubuntu 26.04 with no
+  fix available.  The base docker image does not load the affected modules.  This is effectively equivalent to the
+  "Manual mitigation" documented here: https://ubuntu.com/blog/dirty-frag-linux-vulnerability-fixes-available
 
 ## v2.0
 * The memory footprint for the scheduler has been reduced significantly by removing the use of crond.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,9 +4,12 @@
 * Docker image upgraded to remediate CVE-2026-31431 (Copy Fail)
 * The container now executes as a low-privileged user.
 * Helm chart updates to improve security posture.
-* As of the time of release, CVE-2026-43284 (Dirty Frag) is reported to affect Ubuntu 26.04 with no
-  fix available.  The base docker image does not load the affected modules.  This is effectively equivalent to the
-  "Manual mitigation" documented here: https://ubuntu.com/blog/dirty-frag-linux-vulnerability-fixes-available
+* As of the time of release, Ubuntu 26.04 is has no patches for CVE-2026-43284 (Dirty Frag)
+  and CVE-2026-46300 (Fragnesia, CVE number not yet assigned). These are not currently exploitable
+  in the scan scheduler given that the base docker image does not load the exploitable kernel
+  modules.  The manual mitigation of each can be reviewed to verify that the modules are not loaded:
+    * [CVE-2026-43284 (Dirty Frag)](https://ubuntu.com/blog/dirty-frag-linux-vulnerability-fixes-available)
+    * [CVE-2026-46300 (Fragnesia)](https://ubuntu.com/blog/fragnesia-linux-vulnerability-fixes-available)
 
 ## v2.0
 * The memory footprint for the scheduler has been reduced significantly by removing the use of crond.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## v2.1
 * Docker image upgraded to remediate CVE-2026-31431 (Copy Fail)
 * The container now executes as a low-privileged user.
+* Helm chart updates to improve security posture.
 * As of the time of release, CVE-2026-43284 (Dirty Frag) is reported to affect Ubuntu 26.04 with no
   fix available.  The base docker image does not load the affected modules.  This is effectively equivalent to the
   "Manual mitigation" documented here: https://ubuntu.com/blog/dirty-frag-linux-vulnerability-fixes-available

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## v2.1
+* Docker image upgraded to remediate CVE-2026-31431 (Copy Fail)
+
 ## v2.0
 * The memory footprint for the scheduler has been reduced significantly by removing the use of crond.
 * The `hourly` and `daily` default schedules can now be overridden via configuration.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,14 @@
 #!/bin/bash
 
-update-ca-certificates
-export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-echo "export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt" >> /etc/environment
+cat /etc/ssl/certs/ca-certificates.crt > /opt/cxone/certs.crt
+export REQUESTS_CA_BUNDLE=/opt/cxone/certs.crt
 
-[ -n "$CXONE_REGION" ] && echo "export CXONE_REGION=$CXONE_REGION" >> /etc/environment
-[ -n "$SINGLE_TENANT_AUTH" ] && echo "export SINGLE_TENANT_AUTH=$SINGLE_TENANT_AUTH" >> /etc/environment
-[ -n "$SINGLE_TENANT_API" ] && echo "export SINGLE_TENANT_API=$SINGLE_TENANT_API" >> /etc/environment
-[ -n "$LOG_LEVEL" ] && echo "export LOG_LEVEL=$LOG_LEVEL" >> /etc/environment
-[ -n "$SSL_VERIFY" ] && echo "export SSL_VERIFY=$SSL_VERIFY" >> /etc/environment
-[ -n "$PROXY" ] && echo "export PROXY=$PROXY" >> /etc/environment
-[ -n "$FETCH_THROTTLE" ] && echo "export FETCH_THROTTLE=$FETCH_THROTTLE" >> /etc/environment
-[ -n "$RECENT_SCAN_HOURS" ] && echo "export RECENT_SCAN_HOURS=$RECENT_SCAN_HOURS" >> /etc/environment
-
-if [ -n "$TIMEZONE" ]; then
-    [ -f /usr/share/zoneinfo/$TIMEZONE ] && ln -sf /usr/share/zoneinfo/$TIMEZONE /etc/localtime
-fi
+for cert in $(find /usr/local/share/ca-certificates -name '*.crt' -print);
+do
+    if [[ -n "$LOG_LEVEL" && $LOG_LEVEL == "DEBUG" ]]; then
+        echo Adding $cert as a trusted CA certificate...
+    fi
+    cat $cert >> /opt/cxone/certs.crt
+done
 
 python3 "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ cp /etc/ssl/certs/ca-certificates.crt /opt/cxone/certs/certs.crt
 
 export REQUESTS_CA_BUNDLE=/opt/cxone/certs/certs.crt
 
-for cert in $(find /usr/share/ca-certificates -maxdepth 1 -name '*.crt' -print);
+for cert in $(find /usr/local/share/ca-certificates -maxdepth 1 -name '*.crt' -print);
 do
     if [[ -n "$LOG_LEVEL" && $LOG_LEVEL == "DEBUG" ]]; then
         echo Adding $cert as a trusted CA certificate...

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-cat /etc/ssl/certs/ca-certificates.crt > /opt/cxone/certs.crt
-export REQUESTS_CA_BUNDLE=/opt/cxone/certs.crt
+cp /etc/ssl/certs/ca-certificates.crt /opt/cxone/certs/certs.crt
 
-for cert in $(find /usr/local/share/ca-certificates -name '*.crt' -print);
+export REQUESTS_CA_BUNDLE=/opt/cxone/certs/certs.crt
+
+for cert in $(find /usr/share/ca-certificates -maxdepth 1 -name '*.crt' -print);
 do
     if [[ -n "$LOG_LEVEL" && $LOG_LEVEL == "DEBUG" ]]; then
         echo Adding $cert as a trusted CA certificate...
     fi
-    cat $cert >> /opt/cxone/certs.crt
+    cat $cert >> /opt/cxone/certs/certs.crt
 done
 
 python3 "$@"

--- a/helm/templates/scheduler.yaml
+++ b/helm/templates/scheduler.yaml
@@ -57,6 +57,8 @@ spec:
           image: ghcr.io/checkmarx-ts/cxone/scan-scheduler:{{ .Chart.AppVersion }}
           imagePullPolicy: Always
           securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: nobody
             allowPrivilegeEscalation: false
             seccompProfile:
               type: RuntimeDefault

--- a/helm/templates/scheduler.yaml
+++ b/helm/templates/scheduler.yaml
@@ -58,7 +58,7 @@ spec:
           imagePullPolicy: Always
           securityContext:
             readOnlyRootFilesystem: true
-            runAsUser: nobody
+            runAsUser: 65534
             allowPrivilegeEscalation: false
             seccompProfile:
               type: RuntimeDefault
@@ -73,6 +73,8 @@ spec:
               memory: 32Gi
               cpu: 2
           volumeMounts:
+            - name: scheduler-custom-ca-volume
+              mountPath: "/opt/cxone/certs"
             - name: scheduler-secret-tenant-volume
               mountPath: "/run/secrets/cxone_tenant"
               subPath: cxone_tenant
@@ -82,6 +84,11 @@ spec:
             - name: scheduler-secret-oauth-client-secret-volume
               mountPath: "/run/secrets/cxone_oauth_client_secret"
               subPath: cxone_oauth_client_secret
+          volumes:
+            - name: scheduler-custom-ca-volume
+              emptyDir:
+                medium: Memory
+                sizeLimit: 12Mi
             {{- with .Values.cxone.deployment }}
               {{- if not (empty .ca_certs_configmap_name) }}
             - name: scheduler-custom-ca-certs

--- a/helm/templates/scheduler.yaml
+++ b/helm/templates/scheduler.yaml
@@ -23,6 +23,11 @@ spec:
     spec:
       automountServiceAccountToken: false
       volumes:
+        - name: scheduler-ca-store
+          emptyDir:
+            medium: Memory
+            sizeLimit: 4Mi
+
         {{- with .Values.cxone.deployment }}
 
         - name: scheduler-secret-tenant-volume
@@ -73,7 +78,7 @@ spec:
               memory: 32Gi
               cpu: 2
           volumeMounts:
-            - name: scheduler-custom-ca-volume
+            - name: scheduler-ca-store
               mountPath: "/opt/cxone/certs"
             - name: scheduler-secret-tenant-volume
               mountPath: "/run/secrets/cxone_tenant"
@@ -84,11 +89,6 @@ spec:
             - name: scheduler-secret-oauth-client-secret-volume
               mountPath: "/run/secrets/cxone_oauth_client_secret"
               subPath: cxone_oauth_client_secret
-          volumes:
-            - name: scheduler-custom-ca-volume
-              emptyDir:
-                medium: Memory
-                sizeLimit: 12Mi
             {{- with .Values.cxone.deployment }}
               {{- if not (empty .ca_certs_configmap_name) }}
             - name: scheduler-custom-ca-certs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cron-validator==1.0.8
 aiofiles==24.1.0
-pytest==8.3.4
 APScheduler==3.11.2
 https://github.com/checkmarx-ts/cxone-async-api/releases/download/1.1.3/cxone_api-1.1.3-py3-none-any.whl

--- a/scheduler.py
+++ b/scheduler.py
@@ -66,7 +66,12 @@ while True:
             short_delay = False
             while True:
                 __log.info(f"Projects with scheduled scans: {the_scheduler.scheduled_scans}")
-                await asyncio.sleep(update_delay if not short_delay else 90)
+
+                try:
+                    await asyncio.sleep(update_delay if not short_delay else 90)
+                except asyncio.exceptions.CancelledError:
+                    raise
+
                 __log.info("Updating schedule...")
                 try:
                     new, removed, changed = await the_scheduler.refresh_schedule()
@@ -96,9 +101,13 @@ while True:
             except BaseException as ex:
                 audit_log.exception(ex)
             finally:
-                break
+                exit(1)
         else:
-            asyncio.run(scheduler())
+            try:
+                asyncio.run(scheduler())
+            except KeyboardInterrupt:
+                __log.info("Scheduler Ended")
+                exit(0)
 
     except Exception as ex:
         __log.exception(ex)


### PR DESCRIPTION
* Update base image to a non-vulnerable Ubuntu 26.04.
* Validate that CVE-2026-43284 (DirtyFrag) is also not an issue (see release notes).
* Validate that CVE-2026-46300 (Fragnesia) is also not an issue (see release notes).
* Improve security posture of image runtime by limiting runtime user rights and removing packages that are not needed for runtime.

Resolves #11 